### PR TITLE
Filter validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,10 +110,14 @@ show all posibles values get from data
 to the CodeMirror editor.  
 See https://codemirror.net/doc/manual.html#config
 
+**strictMode: boolean** defaults to false.  Set to true to enforce that all categories and operators in the
+filter query are valid based on the options config.  This validation is applied after the query is successfully parsed.  When the onChange or onParseError events are raised the last argument will indicate if the filter is valid based and also indicate the first invalid item when the validation fails.
+
+
 ## Events
 
-**onChange(query: String, expressions: Expression[]|Error)**: event raised every change of 
-query, together with expressions if parse is ok, otherwise is error
+**onChange(query: String, expressions: Expression[]|Error, validationResult: { isValid: boolean, message?: string })**: event raised every change of query, together with expressions if parse is ok, otherwise is error.
+When strictMode is true, the validiationResult argument will indicate if the filter matches the options config,
 
 ```typescript
 interface Expression {
@@ -128,10 +132,12 @@ interface Expression {
 to see more about the structure of Expression which parsed from query, please
 take a look at: [unit test](https://github.com/nhabuiduc/react-filter-box/blob/master/test/FilterQUeryParser.spec.ts)
 
-**onParseOk(expressions:Expression[])**: event raised when parsing is ok
+**onParseOk(expressions:Expression[])**: event raised when parsing is ok.  When strictMode is true, this also indicates that all categories and operators are valid based on the options config.
 
 
-**onParseError(error:Error)**: event raised when parsing error
+**onParseError(error:Error, validationResult: { isValid: boolean, message?: string })**: 
+event raised when parsing error.  When strictMode is true, the validiationResult argument will indicate if the filter matches the options config,
+
 
 ## Custom Functions
 **customRenderCompletionItem(self:HintResult,data:Completion, registerAndGetPickFunc:Function): ReactComponent**:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adastradev/react-filter-box",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "Conditional filter supports OR/AND, bracket, Highlighting, Autocomplete, and high extensibility   ",
   "scripts": {
     "start": "node server.js",
@@ -71,8 +71,8 @@
     "react-test-renderer": "^16.6.3",
     "sinon": "^7.1.1",
     "style-loader": "^0.23.1",
-    "tslint": "^5.17.0",
     "ts-loader": "^6.2.1",
+    "tslint": "^5.17.0",
     "typescript": "^3.2.1",
     "webpack": "^4.27.0",
     "webpack-cli": "^3.1.2",
@@ -81,7 +81,7 @@
   },
   "dependencies": {
     "codemirror": "^5.42.0",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "pegjs": "^0.10.0",
     "react": "^16.6.3",
     "react-codemirror2": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
-  "name": "react-filter-box",
-  "version": "3.3.0",
+  "name": "@adastradev/react-filter-box",
+  "version": "3.4.0",
   "description": "Conditional filter supports OR/AND, bracket, Highlighting, Autocomplete, and high extensibility   ",
   "scripts": {
     "start": "node server.js",
     "lint": "tslint ./src/**/*.tsx?",
     "test": "node --max-old-space-size=16000 ./node_modules/.bin/mocha-webpack --require ignore-styles -r jsdom-global/register --webpack-config webpack.test.config.js --watch \"./test/**/*.ts\"",
+    "test:windows": "node --max-old-space-size=16000 ./node_modules/mocha-webpack/bin/mocha-webpack --require ignore-styles -r jsdom-global/register --webpack-config webpack.test.config.js  --watch \"./test/**/*.ts\"",
     "dist": "webpack --config webpack.prod.config.js --progress -p",
     "component-package": "webpack --config webpack.component.config.js --progress -p && npm run less",
     "less": "lessc ./src/ReactFilterBox.less ./lib/react-filter-box.css",

--- a/src/BaseAutoCompleteHandler.ts
+++ b/src/BaseAutoCompleteHandler.ts
@@ -57,6 +57,14 @@ export default class BaseAutoCompleteHandler {
         })
     }
 
+    hasCategory(category: string): boolean {
+        return false;
+    } 
+
+    hasOperator(category: string, operator: string): boolean {
+        return false;
+    } 
+
     needCategories(): string[] {
         return []
     }

--- a/src/GridDataAutoCompleteHandler.ts
+++ b/src/GridDataAutoCompleteHandler.ts
@@ -19,6 +19,18 @@ export default class GridDataAutoCompleteHandler extends BaseAutoCompleteHandler
         });
     }
 
+    hasCategory(category: string): boolean {
+      var found = _.find(this.options, f => {
+          return (category === f.columnField || category === f.columnText);
+      });
+
+      return found !== undefined;
+    } 
+
+    hasOperator(category: string, operator: string): boolean {
+        return this.needOperators(category).indexOf(operator) >= 0;
+    } 
+
     needCategories() {
         return this.categories;
     }

--- a/src/ReactFilterBox.tsx
+++ b/src/ReactFilterBox.tsx
@@ -49,21 +49,17 @@ export default class ReactFilterBox extends React.Component<any, any> {
     onSubmit(query: string) {
         var result = this.parser.parse(query);
         if ((result as ParsedError).isError) {
-            return this.props.onParseError(result);
+            return this.props.onParseError(result, { isValid: true });
         } else if (this.props.strictMode) {
             const validationResult = validateQuery(result as Expression[], this.parser.autoCompleteHandler);
-            if (validationResult.isValid === false) {
-                const validationError = new Error(validationResult.message)
-                console.log(validationResult.message);
-                return this.props.onParseError(validationError);
-            }
+            return this.props.onParseError(result, validationResult);
         }
 
         return this.props.onParseOk(result);
     }
 
     onChange(query: string) {
-        var validationResult;
+        var validationResult = { isValid: true };
         var result = this.parser.parse(query);
         if ((result as ParsedError).isError) {
             this.setState({ isError: true })

--- a/src/ReactFilterBox.tsx
+++ b/src/ReactFilterBox.tsx
@@ -52,7 +52,9 @@ export default class ReactFilterBox extends React.Component<any, any> {
             return this.props.onParseError(result, { isValid: true });
         } else if (this.props.strictMode) {
             const validationResult = validateQuery(result as Expression[], this.parser.autoCompleteHandler);
-            return this.props.onParseError(result, validationResult);
+            if (!validationResult.isValid) {
+                return this.props.onParseError(result, validationResult);
+            }
         }
 
         return this.props.onParseOk(result);
@@ -64,10 +66,10 @@ export default class ReactFilterBox extends React.Component<any, any> {
         if ((result as ParsedError).isError) {
             this.setState({ isError: true })
         } else if (this.props.strictMode) {
-          validationResult = validateQuery(result as Expression[], this.parser.autoCompleteHandler);
-          this.setState({ isError: !validationResult.isValid })
+            validationResult = validateQuery(result as Expression[], this.parser.autoCompleteHandler);
+            this.setState({ isError: !validationResult.isValid })
         } else {
-          this.setState({ isError: false })
+            this.setState({ isError: false })
         }
 
         this.props.onChange(query, result, validationResult);

--- a/src/ReactFilterBox.tsx
+++ b/src/ReactFilterBox.tsx
@@ -63,15 +63,18 @@ export default class ReactFilterBox extends React.Component<any, any> {
     }
 
     onChange(query: string) {
+        var validationResult;
         var result = this.parser.parse(query);
-        if ((result as ParsedError).isError ||
-            (this.props.strictMode && !validateQuery(result as Expression[], this.parser.autoCompleteHandler).isValid)) {
-          this.setState({ isError: true })
+        if ((result as ParsedError).isError) {
+            this.setState({ isError: true })
+        } else if (this.props.strictMode) {
+          validationResult = validateQuery(result as Expression[], this.parser.autoCompleteHandler);
+          this.setState({ isError: !validationResult.isValid })
         } else {
           this.setState({ isError: false })
         }
 
-        this.props.onChange(query, result);
+        this.props.onChange(query, result, validationResult);
     }
 
     onBlur() {

--- a/src/validateQuery.ts
+++ b/src/validateQuery.ts
@@ -16,12 +16,12 @@ const validateExpression = (
   const expressions = expression.expressions;
 
   if (expressions === undefined) {
-    if (autoCompleteHandler.needCategories().indexOf(expression.category) < 0) {
+    if (autoCompleteHandler.hasCategory(expression.category) === false) {
       result = {
         isValid: false,
         message: `Invalid category '${expression.category}' in expression ${expression.category} ${expression.operator} ${expression.value}`
       };
-    } else if (autoCompleteHandler.needOperators(expression.category).indexOf(expression.operator) < 0) {
+    } else if (autoCompleteHandler.hasOperator(expression.category, expression.operator) === false) {
       result = {
         isValid: false,
         message: `Invalid operator '${expression.operator}' in expression ${expression.category} ${expression.operator} ${expression.value}`

--- a/src/validateQuery.ts
+++ b/src/validateQuery.ts
@@ -1,0 +1,59 @@
+import * as _ from "lodash";
+import Expression from './Expression';
+import BaseAutoCompleteHandler from './BaseAutoCompleteHandler';
+
+interface ValidationResult {
+  isValid: boolean;
+  message?: string;
+}
+
+const validateExpression = (
+  expression: Expression,
+  autoCompleteHandler: BaseAutoCompleteHandler
+) : ValidationResult => {
+
+  let result: ValidationResult = { isValid: true };
+  const expressions = expression.expressions;
+
+  if (expressions === undefined) {
+    if (autoCompleteHandler.needCategories().indexOf(expression.category) < 0) {
+      result = {
+        isValid: false,
+        message: `Invalid category '${expression.category}' in expression ${expression.category} ${expression.operator} ${expression.value}`
+      };
+    } else if (autoCompleteHandler.needOperators(expression.category).indexOf(expression.operator) < 0) {
+      result = {
+        isValid: false,
+        message: `Invalid operator '${expression.operator}' in expression ${expression.category} ${expression.operator} ${expression.value}`
+      };
+    }
+  } else if (expressions) {
+    _.find(expressions, expr => {
+      result = validateExpression(expr, autoCompleteHandler);
+      return result.isValid === false;
+    });
+  } 
+
+  return result;
+}
+
+
+const validateQuery = (
+    parsedQuery: Expression [],
+    autoCompleteHandler: BaseAutoCompleteHandler
+  ) : ValidationResult => {
+
+  let result: ValidationResult = { isValid: true };
+  _.find(parsedQuery, expr => {
+    result = validateExpression(expr, autoCompleteHandler);
+    return result.isValid === false;
+  });
+
+  return result;
+}
+
+export default validateQuery;
+
+export {
+  ValidationResult
+}

--- a/test/validateQuery.spec.ts
+++ b/test/validateQuery.spec.ts
@@ -1,0 +1,229 @@
+import { expect } from 'chai';
+import validateQuery from "../src/validateQuery";
+import Expression from "../src/Expression";
+import GridDataAutoCompleteHandler, { Option } from '../src/GridDataAutoCompleteHandler';
+// import sinon = require("sinon");
+
+describe("#validateQuery", () => {
+
+    // common fixture data
+    var options: Option[] = [
+        {
+            columnField: 'column1',
+            columnText: 'Column1',
+            type: 'text'
+        },
+        {
+            columnField: 'column2',
+            type: 'text'
+        },
+        {
+            columnField: 'column3',
+            columnText: 'Column3',
+            type: 'text',
+            customOperatorFunc: (category: string): string[] => {
+                return ['**', 'in'];
+            }
+        }
+    ];
+    var autoCompleteHandler = new GridDataAutoCompleteHandler([], options);
+
+    describe("#category validation (all operators are valid)", () => {
+        
+        it("with catogory matching columnField should return isValid set to true", () => {
+            var expression: Expression[] = [
+                {
+                    category: 'column2',
+                    operator: '==',
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            console.log(result);
+            expect(result.isValid).to.be.true;
+        });
+
+        it("with catogory matching columnText should return isValid set to true", () => {
+            var expression: Expression[] = [
+                {
+                    category: 'Column1',
+                    operator: '==',
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.true;
+        });
+
+        it("with non-matching category should return isValid set to false and set message", () => {
+            var expression: Expression[] = [
+                {
+                    category: 'FakeColumn1',
+                    operator: '==',
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.false;
+            expect(result.message.indexOf('Invalid category')).to.eq(0);
+        });
+    });
+
+    describe("#operator validation (all categories are valid)", () => {
+        it("with matching operator should return isValid set to true", () => {
+            var expression: Expression[] = [
+                {
+                    category: 'Column1',
+                    operator: '==',
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.true;
+        });
+
+        it("with matching against custom operator function should return isValid set to true", () => {
+            var expression: Expression[] = [
+                {
+                    category: 'Column3',
+                    operator: '**',
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.true;
+        });
+
+        it("with non-matching operator should return isValid set to false and set message", () => {
+            var expression: Expression[] = [
+                {
+                    category: 'column1',
+                    operator: '=',
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.false;
+            expect(result.message.indexOf('Invalid operator')).to.eq(0);
+        });
+
+        it("with non-matching custom operator should return isValid set to false and set message", () => {
+            var expression: Expression[] = [
+                {
+                    category: 'column3',
+                    operator: '==',
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.false;
+            expect(result.message.indexOf('Invalid operator')).to.eq(0);
+        });
+    });
+
+    describe("#complex expression", () => {
+        it("query with two conditions should return isValid set to true", () => {
+            var expression: Expression[] = [
+                {
+                    conditionType: 'OR',
+                    expressions: [
+                        {
+                            category: 'column2',
+                            operator: '==',
+                        },
+                        {
+                            category: 'column3',
+                            operator: '**',
+                        }
+                    ]
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.true;
+        });
+
+        it("query with two invalid conditions should return isValid set to false", () => {
+            var expression: Expression[] = [
+                {
+                    conditionType: 'OR',
+                    expressions: [
+                        {
+                            category: 'column4',  // invalid column
+                            operator: '==',
+                        },
+                        {
+                            category: 'column3',
+                            operator: '<>',       // invalid operator
+                        }
+                    ]
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.false;
+            expect(result.message.indexOf('Invalid category')).to.eq(0);
+        });
+
+        it("valid query with nested conditions should return isValid set to true", () => {
+            var expression: Expression[] = [
+                {
+                    conditionType: 'OR',
+                    expressions: [
+                        {
+                            category: 'column1',
+                            operator: '==',
+                        },
+                        {
+                            conditionType: 'AND',
+                            expressions: [
+                                {
+                                    category: 'column2',
+                                    operator: 'contains',
+                                },
+                                {
+                                    category: 'column3',
+                                    operator: 'in',
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.true;
+        });
+
+        it("query with invalid nested condition should return isValid set to false", () => {
+            var expression: Expression[] = [
+                {
+                    conditionType: 'OR',
+                    expressions: [
+                        {
+                            category: 'column1',
+                            operator: '==',
+                        },
+                        {
+                            conditionType: 'AND',
+                            expressions: [
+                                {
+                                    category: 'column2',
+                                    operator: 'contains',
+                                },
+                                {
+                                    category: 'column3',
+                                    operator: '==',  // invalid operator
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ];
+
+            var result = validateQuery(expression, autoCompleteHandler);
+            expect(result.isValid).to.be.false;
+            expect(result.message.indexOf('Invalid operator')).to.eq(0);
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3936,10 +3936,10 @@ lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.15:
-  version "4.17.15"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
-  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
 
 loglevel@^1.6.4:
   version "1.6.4"


### PR DESCRIPTION
This feature validates that the categories and operators in the filter text match what is in the options configuration if the strictMode prop is set to true.  I tried to build it without changing any interface except adding an argument to the onParseError and onChange callbacks.  It still needs some unit tests and documentation.

Let me know if you would consider adding this feature.  Otherwise we are going to have to start maintaining our own fork.