### PR TITLE
upping react-codemirror2 version to fix deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "lodash": "^4.17.19",
     "pegjs": "^0.10.0",
     "react": "^16.6.3",
-    "react-codemirror2": "^5.1.0",
+    "react-codemirror2": "6.0.1",
     "react-dom": "^16.6.3"
   },
   "resolutions": {


### PR DESCRIPTION
https://github.com/scniro/react-codemirror2/pull/176

This should remove this warning: 

```
Warning: componentWillMount has been renamed, and is not recommended for use. See https://fb.me/react-unsafe-component-lifecycles for details.

* Move code with side effects to componentDidMount, and set initial state in the constructor.
* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 17.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: e
```